### PR TITLE
Retractions now throw a validation error.

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,6 +166,12 @@ for file in glob.glob("forecasts/*.csv"):
                     errors[os.path.basename(file)].append(compare_result['error'])
             if compare_result['retraction'] and not local:
                 pr.add_to_labels('forecast-retraction')
+                retract_error = f"The forecast {os.path.basename(file)} has an invalid retraction. Please review the retraction rules for a forecast in the wiki here - https://github.com/reichlab/covid19-forecast-hub/wiki/Forecast-Checks"
+                # throw an error now with Zoltar 4
+                if len(error_file) == 0:
+                    errors[os.path.basename(file)] = [retract_error]
+                else:
+                    errors[os.path.basename(file)].append(retract_error)
 
     # Check for the forecast date column check is +-1 day from the current date the PR build is running
     is_val_err, err_message = filename_match_forecast_date(file)


### PR DESCRIPTION
## What's there in the PR? 
With the Zoltar 4 update, we now need to throw an error whenever an invalid retraction is made. This change adds an error at this step.